### PR TITLE
Use module_name instead of object_name.lower()

### DIFF
--- a/armstrong/core/arm_layout/backends.py
+++ b/armstrong/core/arm_layout/backends.py
@@ -8,8 +8,14 @@ class BasicRenderModelBackend(object):
         for a in model.__class__.mro():
             if not hasattr(a, "_meta"):
                 continue
+
+            try:
+                model_name = a._meta.model_name
+            except AttributeError:  # DJANGO15 model_name is used in 1.6+
+                model_name = a._meta.module_name
+
             ret.append("layout/%s/%s/%s.html" %
-                (a._meta.app_label, a._meta.module_name, name))
+                (a._meta.app_label, model_name, name))
         return ret
 
     def render(self, object, name, dictionary=None,

--- a/armstrong/core/arm_layout/tests/arm_layout_support/models.py
+++ b/armstrong/core/arm_layout/tests/arm_layout_support/models.py
@@ -1,8 +1,15 @@
+import django
 from django.db import models
 
 
 class Foobar(models.Model):
     title = models.CharField(max_length=100)
+
+    # DJANGO15 drop this when we drop Django 1.5 support
+    if django.VERSION < (1, 6):
+        def __init__(self, *args, **kwargs):
+            super(Foobar, self).__init__(*args, **kwargs)
+            self._meta.model_name = self._meta.module_name
 
 
 class SubFoobar(Foobar):


### PR DESCRIPTION
This is a minor refactor to follow the Django paradigm. Using `module_name` has been standard practice for a while, at least [since 1.0](https://github.com/django/django/blob/1.0/django/db/models/options.py#L59-L60).

_Note:_ this will change in 1.6 to `model_name`. See https://code.djangoproject.com/ticket/19689
