### PR TITLE
Fix random fails in tests

### DIFF
--- a/armstrong/core/arm_layout/tests/templatetags/layout_helpers.py
+++ b/armstrong/core/arm_layout/tests/templatetags/layout_helpers.py
@@ -9,7 +9,7 @@ from ..arm_layout_support.models import Foobar
 from .._utils import TestCase
 
 
-def generate_random_model(count):
+def generate_random_models(count):
     """Generator to create ``count`` number of unique random models"""
 
     num = random.randint(1000, 2000)
@@ -44,7 +44,7 @@ class RenderBaseTestCaseMixin(object):
 class RenderModelTestCase(RenderBaseTestCaseMixin, TestCase):
     def setUp(self):
         super(RenderModelTestCase, self).setUp()
-        self.model = next(generate_random_model(1))
+        self.model = next(generate_random_models(1))
         self.context['model_obj'] = self.model
         self.expected_result = "Full - Title: %s" % self.model.title
 
@@ -154,19 +154,19 @@ class RenderListTestCase(RenderBaseTestCaseMixin, TestCase):
             self.rendered_template
 
     def test_raises_exception_on_too_many_parameters(self):
-        self.context['list'] = [next(generate_random_model(1))]
+        self.context['list'] = list(generate_random_models(1))
         self.string = '{% render_list list "full" one_too_many %}'
         with self.assertRaisesRegexp(TemplateSyntaxError, "Too many parameters"):
             self.rendered_template
 
     def test_raises_exception_on_too_few_parameters(self):
-        self.context['list'] = [next(generate_random_model(1))]
+        self.context['list'] = list(generate_random_models(1))
         self.string = '{% render_list list %}'
         with self.assertRaisesRegexp(TemplateSyntaxError, "Too few parameters"):
             self.rendered_template
 
     def test_renders_all_list_items(self):
-        models = [i for i in generate_random_model(3)]
+        models = list(generate_random_models(3))
 
         self.context['list'] = models
         self.string = '{% render_list list "full" %}'
@@ -178,7 +178,7 @@ class RenderListTestCase(RenderBaseTestCaseMixin, TestCase):
 
     def test_variable_resolution_for_list(self):
         random_list_var = "var_%d" % random.randint(100, 200)
-        models = [i for i in generate_random_model(2)]
+        models = list(generate_random_models(2))
 
         self.context[random_list_var] = models
         self.string = '{% render_list ' + random_list_var + ' "full" %}'
@@ -189,14 +189,14 @@ class RenderListTestCase(RenderBaseTestCaseMixin, TestCase):
     def test_variable_resolution_for_template(self):
         random_tpl_var = "name_%d" % random.randint(100, 200)
 
-        self.context['list'] = [i for i in generate_random_model(2)]
+        self.context['list'] = list(generate_random_models(2))
         self.string = '{% render_list list "' + random_tpl_var + '" %}'
 
         with self.assertRaisesRegexp(TemplateDoesNotExist, "%s.html" % random_tpl_var):
             self.rendered_template
 
     def test_filters_work_on_list_argument(self):
-        models = [i for i in generate_random_model(5)]
+        models = list(generate_random_models(5))
 
         self.context['list'] = models
         self.string = '{% render_list list|slice:":2" "full" %}'
@@ -206,7 +206,7 @@ class RenderListTestCase(RenderBaseTestCaseMixin, TestCase):
         self.assertFalse(models[2].title in self.rendered_template)
 
     def test_filters_work_on_template_argument(self):
-        models = [i for i in generate_random_model(2)]
+        models = list(generate_random_models(2))
 
         self.context['list'] = models
         self.string = '{% render_list list "full_extra"|slice:":4" %}'
@@ -232,7 +232,7 @@ class RenderIterTestCase(RenderBaseTestCaseMixin, TestCase):
         return self._rendered_template
 
     def test_iter_raises_exception_on_too_many_parameters(self):
-        self.context['list'] = [next(generate_random_model(1))]
+        self.context['list'] = list(generate_random_models(1))
         template = '{% load layout_helpers %}{% render_iter list one_too_many %}{% endrender_iter %}'
         with self.assertRaisesRegexp(TemplateSyntaxError, "Too many parameters"):
             Template(template).render(self.context)
@@ -243,25 +243,25 @@ class RenderIterTestCase(RenderBaseTestCaseMixin, TestCase):
             Template(template).render(self.context)
 
     def test_next_raises_exception_on_too_many_parameters(self):
-        self.context['list'] = [next(generate_random_model(1))]
+        self.context['list'] = list(generate_random_models(1))
         self.string = '{% render_next "mini" one_too_many %}'
         with self.assertRaisesRegexp(TemplateSyntaxError, "Too many parameters"):
             self.rendered_template
 
     def test_next_raises_exception_on_too_few_parameters(self):
-        self.context['list'] = [next(generate_random_model(1))]
+        self.context['list'] = list(generate_random_models(1))
         self.string = '{% render_next %}'
         with self.assertRaisesRegexp(TemplateSyntaxError, "Too few parameters"):
             self.rendered_template
 
     def test_remainder_raises_exception_on_too_many_parameters(self):
-        self.context['list'] = [next(generate_random_model(1))]
+        self.context['list'] = list(generate_random_models(1))
         self.string = '{% render_remainder "mini" one_too_many %}'
         with self.assertRaisesRegexp(TemplateSyntaxError, "Too many parameters"):
             self.rendered_template
 
     def test_remainder_raises_exception_on_too_few_parameters(self):
-        self.context['list'] = [next(generate_random_model(1))]
+        self.context['list'] = list(generate_random_models(1))
         self.string = '{% render_remainder %}'
         with self.assertRaisesRegexp(TemplateSyntaxError, "Too few parameters"):
             self.rendered_template
@@ -276,13 +276,13 @@ class RenderIterTestCase(RenderBaseTestCaseMixin, TestCase):
             self.rendered_template
 
     def test_render_one_element(self):
-        model = next(generate_random_model(1))
+        model = next(generate_random_models(1))
         self.context['list'] = [model]
         self.string = '{% render_next "full" %}'
         self.assertEqual('Full - Title: %s' % model.title, self.rendered_template)
 
     def test_render_multiple_elements(self):
-        models = [i for i in generate_random_model(5)]
+        models = list(generate_random_models(5))
 
         self.context['list'] = models
         self.string = ''.join([
@@ -296,7 +296,7 @@ class RenderIterTestCase(RenderBaseTestCaseMixin, TestCase):
         self.assertFalse(models[3].title in self.rendered_template)
 
     def test_render_multiple_elements_with_remainder(self):
-        models = [i for i in generate_random_model(7)]
+        models = list(generate_random_models(7))
 
         self.context['list'] = models
         self.string = ''.join([
@@ -319,7 +319,7 @@ class RenderIterTestCase(RenderBaseTestCaseMixin, TestCase):
         self.assertEqual(self.rendered_template, "")
 
     def test_render_ignores_extras(self):
-        models = [i for i in generate_random_model(2)]
+        models = list(generate_random_models(2))
 
         self.context['list'] = models
         self.string = ''.join([
@@ -333,7 +333,7 @@ class RenderIterTestCase(RenderBaseTestCaseMixin, TestCase):
         self.assertFalse('mini' in self.rendered_template)
 
     def test_iter_variable_resolution_for_list(self):
-        models = [next(generate_random_model(1))]
+        models = list(generate_random_models(1))
 
         self.variable_name = "var_%d" % random.randint(100, 200)
         self.context[self.variable_name] = models
@@ -344,7 +344,7 @@ class RenderIterTestCase(RenderBaseTestCaseMixin, TestCase):
     def test_next_variable_resolution_for_template(self):
         random_tpl_var = "name_%d" % random.randint(100, 200)
 
-        self.context['list'] = [i for i in generate_random_model(2)]
+        self.context['list'] = list(generate_random_models(2))
         self.string = '{% render_next "' + random_tpl_var + '" %}'
 
         with self.assertRaisesRegexp(TemplateDoesNotExist, "%s.html" % random_tpl_var):
@@ -353,14 +353,14 @@ class RenderIterTestCase(RenderBaseTestCaseMixin, TestCase):
     def test_remainder_variable_resolution_for_template(self):
         random_tpl_var = "name_%d" % random.randint(100, 200)
 
-        self.context['list'] = [i for i in generate_random_model(2)]
+        self.context['list'] = list(generate_random_models(2))
         self.string = '{% render_remainder "' + random_tpl_var + '" %}'
 
         with self.assertRaisesRegexp(TemplateDoesNotExist, "%s.html" % random_tpl_var):
             self.rendered_template
 
     def test_filters_work_on_list_argument(self):
-        models = [i for i in generate_random_model(2)]
+        models = list(generate_random_models(2))
 
         self.context['list'] = models
         self.string = '{% render_remainder "full" %}'
@@ -370,7 +370,7 @@ class RenderIterTestCase(RenderBaseTestCaseMixin, TestCase):
         self.assertFalse(models[1].title in self.rendered_template)
 
     def test_filters_work_on_template_argument(self):
-        models = [i for i in generate_random_model(2)]
+        models = list(generate_random_models(2))
 
         self.context['list'] = models
         self.string = ''.join([


### PR DESCRIPTION
This fixes a problem I've seen for a while. Periodic tests failed because `generate_random_model()` would generate the _same_ `randint` on repeated calls. It was bound to happen.

As the function already has `generate` in its name, might as well embrace. Now the function returns a generator of `count` models all guaranteed to have unique titles.

Sample output:

```
>>> from armstrong.core.arm_layout.tests.templatetags import generate_random_model
>>> next(generate_random_models(1)).title
'This is a random title 1852'
>>> list(generate_random_models(5))
['This is a random title 1405', 'This is a random title 1413', 'This is a random title 1432', 'This is a random title 14
51', 'This is a random title 1453']
>>> list(generate_random_models(5))
['This is a random title 1511', 'This is a random title 1515', 'This is a random title 1526', 'This is a random title 15
33', 'This is a random title 1542']
```
